### PR TITLE
Added support for BSP patch files

### DIFF
--- a/codemp/qcommon/cm_load.cpp
+++ b/codemp/qcommon/cm_load.cpp
@@ -728,6 +728,7 @@ static void CM_LoadMap_Actual( const char *name, qboolean clientload, int *check
 
 		// Use the patched binary stream, checksum will still be the old one
 		if ( patchedBuf ) {
+			Z_Free( buf ); // free the old buffer
 			buf = ( int* )patchedBuf;
 
 			if ( &cm == &cmg )
@@ -737,6 +738,7 @@ static void CM_LoadMap_Actual( const char *name, qboolean clientload, int *check
 			}
 		} else {
 			Com_Printf( "Could not load patch file %s.patch\n", name );
+			Z_Free( patchedBuf );
 		}
 	}
 


### PR DESCRIPTION
When loading maps/onasi_is_easy.bsp, server will look for maps/onasi_is_easy.bsp.patched and use that one if it exists.

The map checksum will still be calculated with the non-patched version. This allows server owners to have a base folder with clean pk3s for basejka auto dl purposes (and generally as a better habit) while being able to put up hotfix for maps.

Patch files can be loaded as loose (unpacked) files in the filesystem or if you have multiple, you can put them all in a single pk3 (not in the original map pk3 though as it breaks the checksum).
